### PR TITLE
optimize and fix intent vectors

### DIFF
--- a/sources/intent.move
+++ b/sources/intent.move
@@ -11,14 +11,14 @@ Flow
 --- To execute a proposal ---
 
 3 - Create the Intent with the IntentPayload
-4 - Deposit all required objects
+4 - Deposit all returned objects
 5 - Share Intent
 
 --- Happy Path someone executes ---
 
 6 - Call start
 7 - Take objects
-8 - Return objects (if required)
+8 - Return objects (if returned)
 9 - Call end
 
 --- Unhappy Path, the deadline has passed without it being executed ---
@@ -43,13 +43,14 @@ module intent::intent {
     const ECallStartFirst: u64 = 0;
     const EHasExpired: u64 = 1;
     const EIsAlreadyInitiated: u64 = 2;
-    const ENotARequiredObject: u64 = 3;
-    const EMissingRequiredObjects: u64 = 4;
-    const EInvalidLock: u64 = 5;
-    const EMissingRequestedObjects: u64 = 6;
-    const EHasNotExpired: u64 = 7;
-    const EHasBeenInitiated: u64 = 8;
-    const ECannotBeShared: u64 = 9;
+    const ENotAnObjectToReturn: u64 = 3;
+    const ENotARequestedObject: u64 = 4;
+    const EObjectsNotReturned: u64 = 5;
+    const EInvalidLock: u64 = 6;
+    const EMissingRequestedObjects: u64 = 7;
+    const EHasNotExpired: u64 = 8;
+    const EHasBeenInitiated: u64 = 9;
+    const ECannotBeShared: u64 = 10;
 
     // === Constants ===
 
@@ -66,9 +67,8 @@ module intent::intent {
         initiated: bool,
         shared: bool,
         requested: vector<address>,
-        deposited: vector<address>,
-        returned: vector<address>,
-        required: vector<address>,      
+        to_deposit: vector<address>,
+        to_return: vector<address>,    
     }
 
     public struct ShareLock {
@@ -84,12 +84,12 @@ module intent::intent {
     // === Public-Mutative Functions ===
 
     public fun new<Executor: drop, Config: store>(payload: IntentPayload<Executor, Config>, ctx: &mut TxContext): (Intent<Executor>, ShareLock) {
-        let (name, owner, deadline, requested, required) = (
+        let (name, owner, deadline, requested, to_return) = (
             payload.name(),
             payload.owner(),
             payload.deadline(),
             payload.requested(),
-            payload.required()
+            payload.to_return()
         );
 
         let mut storage = object::new(ctx);
@@ -105,9 +105,8 @@ module intent::intent {
             name,
             deadline,
             requested,
-            deposited: vector[],
-            returned: vector[],
-            required
+            to_deposit: requested,
+            to_return
         };
 
         let share_lock = ShareLock { intent: intent.id.uid_to_address() };
@@ -115,28 +114,27 @@ module intent::intent {
         (intent, share_lock)
     }
 
-    public fun share<Executor: drop>(mut self: Intent<Executor>, share_lock: ShareLock) {
-        let ShareLock { intent } = share_lock;
-
-        assert!(intent == self.id.uid_to_address(), EInvalidLock);
-
-        assert_vectors_equality(self.requested, self.deposited, EMissingRequestedObjects);
-
-        self.shared = true;
-
-        transfer::share_object(self);
-    }
-
     public fun deposit<Executor: drop, Object: store + key>(self: &mut Intent<Executor>, object: Object) {
         assert!(!self.initiated, EIsAlreadyInitiated);
         assert!(!self.shared, ECannotBeShared);
 
         let object_id = object::id(&object).id_to_address();
+        let (contains, idx) = self.to_deposit.index_of(&object_id);
+        assert!(contains, ENotARequestedObject);
+        self.to_deposit.swap_remove(idx);
 
-        assert!(self.requested.contains(&object_id), ENotARequiredObject);
-
-        self.deposited.push_back(object_id);
         dof::add(&mut self.storage, object_id, object);
+    }
+
+    #[allow(lint(share_owned))]
+    public fun share<Executor: drop>(mut self: Intent<Executor>, share_lock: ShareLock) {
+        let ShareLock { intent } = share_lock;
+
+        assert!(intent == self.id.uid_to_address(), EInvalidLock);
+        assert!(self.to_deposit.is_empty(), EMissingRequestedObjects);
+
+        self.shared = true;
+        transfer::share_object(self);
     }
 
     public fun start<Executor: drop>(self: &mut Intent<Executor>, _: Executor, ctx: &mut TxContext): Lock {
@@ -152,20 +150,22 @@ module intent::intent {
 
     public fun put<Executor: drop, Object: store + key>(self: &mut Intent<Executor>, object: Object) {
         assert!(self.initiated, ECallStartFirst);
-        self.returned.push_back(object::id(&object).id_to_address());
+
+        let (contains, idx) = self.to_return.index_of(&object::id(&object).id_to_address());
+        assert!(contains, ENotAnObjectToReturn);
+        self.to_return.swap_remove(idx);
         transfer::public_transfer(object, self.owner);
     }    
 
     public fun end<Executor: drop>(self: Intent<Executor>, lock: Lock) {
-        let Intent { id, storage, owner: _, initiated, name: _, deadline: _, requested: _, deposited: _, returned, required, shared: _ } = self;
+        let Intent { id, storage, owner: _, initiated, name: _, deadline: _, requested: _, to_deposit: _, to_return, shared: _ } = self;
 
         assert!(initiated, ECallStartFirst);
 
         let Lock { intent } = lock;
 
         assert!(id.uid_to_address() == intent, EInvalidLock);
-        
-        assert_vectors_equality(required, returned, EMissingRequiredObjects);
+        assert!(to_return.is_empty(), EObjectsNotReturned);
 
         id.delete();
         storage.delete();
@@ -177,7 +177,9 @@ module intent::intent {
 
         let object = dof::remove<address, Object>(&mut self.storage, object_id);
 
-        self.returned.push_back(object_id);
+        let (contains, idx) = self.requested.index_of(&object_id);
+        assert!(contains, ENotARequestedObject);
+        self.requested.swap_remove(idx);
 
         transfer::public_transfer(object, self.owner);
     }
@@ -186,9 +188,9 @@ module intent::intent {
         assert!(ctx.epoch() > self.deadline, EHasNotExpired);
         assert!(!self.initiated, EHasBeenInitiated);
         
-        let Intent { id, storage, owner: _, initiated: _, name: _, deadline: _, requested: _, deposited: _, returned, required, shared: _ } = self;
+        let Intent { id, storage, owner: _, initiated: _, name: _, deadline: _, requested, to_deposit: _, to_return: _, shared: _ } = self;
 
-        assert_vectors_equality(required, returned, EMissingRequiredObjects);
+        assert!(requested.is_empty(), EMissingRequestedObjects);
 
         id.delete();
         storage.delete();
@@ -212,16 +214,12 @@ module intent::intent {
         self.requested
     }
 
-    public fun deposited<Executor: drop>(self: &Intent<Executor>): vector<address> {
-        self.deposited
+    public fun to_deposit<Executor: drop>(self: &Intent<Executor>): vector<address> {
+        self.to_deposit
     }
 
-    public fun returned<Executor: drop>(self: &Intent<Executor>): vector<address> {
-        self.returned
-    }
-
-    public fun required<Executor: drop>(self: &Intent<Executor>): vector<address> {
-        self.returned
+    public fun to_return<Executor: drop>(self: &Intent<Executor>): vector<address> {
+        self.to_return
     }
 
     public fun config_mut<Executor: drop, Config: store>(self: &mut Intent<Executor>, _: Executor): &mut Config {
@@ -233,18 +231,6 @@ module intent::intent {
     // === Public-Package Functions ===
 
     // === Private Functions ===
-
-    fun assert_vectors_equality(x: vector<address>, y: vector<address>, error: u64) {
-        let mut i = 0;
-        let len = x.length();
-
-        assert!(len == y.length(), error);
-
-        while (len > i) {
-            assert!(x.contains(&y[i]), error);
-            i = i + 1;
-        };        
-    }
 
     // === Test Functions ===
 }

--- a/sources/intent_payload.move
+++ b/sources/intent_payload.move
@@ -16,7 +16,7 @@ module intent::intent_payload {
         owner: address,
         deadline: u64,
         requested: vector<address>,
-        to_return: vector<address>,
+        required: vector<address>,
         config: Config
     }
 
@@ -29,7 +29,7 @@ module intent::intent_payload {
         owner: address,
         deadline: u64,
         requested: vector<address>,
-        to_return: vector<address>,
+        required: vector<address>,
         config: Config,
         ctx: &mut TxContext        
     ): IntentPayload<Executor, Config> {
@@ -39,7 +39,7 @@ module intent::intent_payload {
             owner,
             deadline,
             requested,
-            to_return,
+            required,
             config
         }
     }
@@ -50,7 +50,7 @@ module intent::intent_payload {
             owner: _,
             deadline: _,
             requested: _,
-            to_return: _, 
+            required: _, 
             config
         } = self;
 
@@ -75,8 +75,8 @@ module intent::intent_payload {
         self.requested
     }
 
-    public fun to_return<Executor: drop, Config: store>(self: &IntentPayload<Executor, Config>): vector<address> {
-        self.to_return
+    public fun required<Executor: drop, Config: store>(self: &IntentPayload<Executor, Config>): vector<address> {
+        self.required
     }
 
     public fun config<Executor: drop, Config: store>(self: &IntentPayload<Executor, Config>): &Config {

--- a/sources/intent_payload.move
+++ b/sources/intent_payload.move
@@ -16,7 +16,7 @@ module intent::intent_payload {
         owner: address,
         deadline: u64,
         requested: vector<address>,
-        required: vector<address>,
+        to_return: vector<address>,
         config: Config
     }
 
@@ -29,7 +29,7 @@ module intent::intent_payload {
         owner: address,
         deadline: u64,
         requested: vector<address>,
-        required: vector<address>,
+        to_return: vector<address>,
         config: Config,
         ctx: &mut TxContext        
     ): IntentPayload<Executor, Config> {
@@ -39,7 +39,7 @@ module intent::intent_payload {
             owner,
             deadline,
             requested,
-            required,
+            to_return,
             config
         }
     }
@@ -50,37 +50,37 @@ module intent::intent_payload {
             owner: _,
             deadline: _,
             requested: _,
-            required: _, 
+            to_return: _, 
             config
-         } = self;
+        } = self;
 
-         config
+        config
     }
 
     // === Public-View Functions ===
 
     public fun name<Executor: drop, Config: store>(self: &IntentPayload<Executor, Config>): String {
-     self.name
+        self.name
     }
 
     public fun owner<Executor: drop, Config: store>(self: &IntentPayload<Executor, Config>): address {
-     self.owner
+        self.owner
     }
 
     public fun deadline<Executor: drop, Config: store>(self: &IntentPayload<Executor, Config>): u64 {
-     self.deadline
+        self.deadline
     }
 
     public fun requested<Executor: drop, Config: store>(self: &IntentPayload<Executor, Config>): vector<address> {
-     self.requested
+        self.requested
     }
 
-    public fun required<Executor: drop, Config: store>(self: &IntentPayload<Executor, Config>): vector<address> {
-     self.required
+    public fun to_return<Executor: drop, Config: store>(self: &IntentPayload<Executor, Config>): vector<address> {
+        self.to_return
     }
 
     public fun config<Executor: drop, Config: store>(self: &IntentPayload<Executor, Config>): &Config {
-     &self.config
+        &self.config
     }
 
     // === Admin Functions ===


### PR DESCRIPTION
Removes the need for 4 vectors.
Add check to `take` to prevent objects to remain in the Intent after completion.